### PR TITLE
added systemd service file

### DIFF
--- a/systemd/sickmuse.service
+++ b/systemd/sickmuse.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Sick Muse is an open source web application graphing RRD data stored by collectd.
+After=local-fs.target network.target
+
+[Service]
+ExecStart=/usr/bin/sickmuse --rrd_directory=/var/lib/collectd/ --logging=warning
+User=http
+Group=http
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Just in case you're interested. I wrote it to be able to start sickmuse with `systemctl` or `systemctl --user` conventiently.