### PR TITLE
Add support for listening on given address.

### DIFF
--- a/sickmuse/app.py
+++ b/sickmuse/app.py
@@ -15,6 +15,7 @@ from sickmuse.handlers import RootHandler, HostHandler, MetricAPIHandler
 
 
 define("port", default=8282, type=int, help="Server port")
+define("listen", default='', type=str, help="Server listen address")
 define("debug", default=False, type=bool, help="Run in debug mode")
 define("rrd_directory", default="/var/lib/collectd/rrd/", help="RRD file storage location")
 define("prefix", default="", help="URL prefix")
@@ -108,7 +109,7 @@ def main():
     # This will also catch KeyboardInterrupt exception
     signal.signal(signal.SIGINT, lambda sig, frame: shutdown(server, False))
     # Start the server
-    server.listen(options.port, "")
+    server.listen(options.port, options.listen)
     IOLoop.instance().start()
 
 


### PR DESCRIPTION
This is done by the --listen command-line argument.

I find this very useful for servers that have multiple network addresses (we don't all have servers dedicated to monitoring!). In my case, I have a publically-accessible eth0 and an internal eth1, as this server also hosts a VPN. While it's certainly possible to use a firewall to reject external connections (and I do that in addition), this seems cleaner to me.

Thanks for a wonderful collectd frontend!
